### PR TITLE
Update AGP & Kotlin version, use AndroidX, fix sample app, make stories progress view resizable, enable resizable gaps & rounded corners

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ To do this, you can add the attributes to your layout xml:
 </LinearLayout>
 ```
 ## Compose support
-None planned.
+None planned. PRs welcome!
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ To do this, you can add the attributes to your layout xml:
    <!-- ... -->
 </LinearLayout>
 ```
-
+## Compose support
+None planned.
 
 ## License
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,34 +2,33 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-  compileSdkVersion 28
-  buildToolsVersion '28.0.3'
-  defaultConfig {
-    applicationId "com.teresaholfeld.stories.app"
-    minSdkVersion 15
-    targetSdkVersion 28
-    versionCode 1
-    versionName "1.0"
-    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-  }
-  buildTypes {
-    release {
-      minifyEnabled false
-      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+    compileSdkVersion 30
+    defaultConfig {
+        applicationId "com.teresaholfeld.stories.app"
+        minSdkVersion 15
+        targetSdkVersion 30
+        versionCode 1
+        versionName "1.0"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
-  }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
 }
 
 dependencies {
-  implementation 'com.github.teresaholfeld:Stories:1.1.2'
-  implementation 'com.android.support:appcompat-v7:28.0.0'
-  implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-  testImplementation 'junit:junit:4.12'
-  androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
-    exclude group: 'com.android.support', module: 'support-annotations'
-  })
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
+    testImplementation 'junit:junit:4.13'
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.3.0', {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    })
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation project(':library')
 }
 repositories {
-  mavenCentral()
+    mavenCentral()
 }

--- a/app/src/main/java/com/teresaholfeld/stories/app/MainActivity.kt
+++ b/app/src/main/java/com/teresaholfeld/stories/app/MainActivity.kt
@@ -1,11 +1,11 @@
 package com.teresaholfeld.stories.app
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
 import android.view.MotionEvent
 import android.view.View
 import android.view.WindowManager
 import android.widget.ImageView
+import androidx.appcompat.app.AppCompatActivity
 import com.teresaholfeld.stories.StoriesProgressView
 
 class MainActivity : AppCompatActivity(), StoriesProgressView.StoriesListener {
@@ -15,12 +15,12 @@ class MainActivity : AppCompatActivity(), StoriesProgressView.StoriesListener {
 
     private var counter = 0
     private val resources = intArrayOf(
-            R.drawable.sample1,
-            R.drawable.sample2,
-            R.drawable.sample3,
-            R.drawable.sample4,
-            R.drawable.sample5,
-            R.drawable.sample6
+        R.drawable.sample1,
+        R.drawable.sample2,
+        R.drawable.sample3,
+        R.drawable.sample4,
+        R.drawable.sample5,
+        R.drawable.sample6
     )
 
     private val durations = longArrayOf(500L, 1000L, 1500L, 4000L, 5000L, 1000)

--- a/app/src/main/java/com/teresaholfeld/stories/app/MainActivity.kt
+++ b/app/src/main/java/com/teresaholfeld/stories/app/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.teresaholfeld.stories.app
 
 import android.os.Bundle
-import android.view.MotionEvent
 import android.view.View
 import android.view.WindowManager
 import android.widget.ImageView
@@ -10,7 +9,7 @@ import com.teresaholfeld.stories.StoriesProgressView
 
 class MainActivity : AppCompatActivity(), StoriesProgressView.StoriesListener {
 
-    private var storiesProgressView: StoriesProgressView? = null
+    private lateinit var storiesProgressView: StoriesProgressView
     private var image: ImageView? = null
 
     private var counter = 0
@@ -23,54 +22,34 @@ class MainActivity : AppCompatActivity(), StoriesProgressView.StoriesListener {
         R.drawable.sample6
     )
 
-    private val durations = longArrayOf(500L, 1000L, 1500L, 4000L, 5000L, 1000)
-
-    private var pressTime = 0L
-    private var limit = 500L
-
-    private val onTouchListener = View.OnTouchListener { v, event ->
-        when (event.action) {
-            MotionEvent.ACTION_DOWN -> {
-                pressTime = System.currentTimeMillis()
-                storiesProgressView?.pause()
-                return@OnTouchListener false
-            }
-            MotionEvent.ACTION_UP -> {
-                val now = System.currentTimeMillis()
-                storiesProgressView?.resume()
-                return@OnTouchListener limit < now - pressTime
-            }
-        }
-        false
-    }
+//    private val durations = longArrayOf(500L, 1000L, 1500L, 4000L, 5000L, 1000)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
         setContentView(R.layout.activity_main)
 
-        storiesProgressView?.setStoriesCount(PROGRESS_COUNT)
-        storiesProgressView?.setStoryDuration(3000L)
+        storiesProgressView = findViewById(R.id.stories)
+        storiesProgressView.setStoriesCount(PROGRESS_COUNT)
+        storiesProgressView.setStoryDuration(3000L)
         // or
         // storiesProgressView.setStoriesCountWithDurations(durations);
 
-        storiesProgressView?.setStoriesListener(this)
+        storiesProgressView.setStoriesListener(this)
 
         counter = 2
-        storiesProgressView?.startStories(counter)
+        storiesProgressView.startStories(counter)
 
         image = findViewById<View>(R.id.image) as ImageView
         image?.setImageResource(resources[counter])
 
         // bind reverse view
         val reverse = findViewById<View>(R.id.reverse)
-        reverse.setOnClickListener { storiesProgressView?.reverse() }
-        reverse.setOnTouchListener(onTouchListener)
+        reverse.setOnClickListener { storiesProgressView.reverse() }
 
         // bind skip view
         val skip = findViewById<View>(R.id.skip)
-        skip.setOnClickListener { storiesProgressView?.skip() }
-        skip.setOnTouchListener(onTouchListener)
+        skip.setOnClickListener { storiesProgressView.skip() }
     }
 
     override fun onNext() {
@@ -86,7 +65,7 @@ class MainActivity : AppCompatActivity(), StoriesProgressView.StoriesListener {
 
     override fun onDestroy() {
         // Very important !
-        storiesProgressView?.destroy()
+        storiesProgressView.destroy()
         super.onDestroy()
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
-       xmlns:app="http://schemas.android.com/apk/res-auto"
-       xmlns:tools="http://schemas.android.com/tools"
-       android:layout_width="match_parent"
-       android:layout_height="match_parent">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <ImageView
         android:id="@+id/image"
@@ -11,7 +11,7 @@
         android:layout_height="match_parent"
         android:contentDescription="@null"
         android:scaleType="centerCrop"
-        tools:src="@drawable/sample1"/>
+        tools:src="@drawable/sample1" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -22,13 +22,13 @@
             android:id="@+id/reverse"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_weight="1"/>
+            android:layout_weight="1" />
 
         <View
             android:id="@+id/skip"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_weight="1"/>
+            android:layout_weight="1" />
     </LinearLayout>
 
     <com.teresaholfeld.stories.StoriesProgressView
@@ -40,5 +40,5 @@
         android:paddingLeft="8dp"
         android:paddingRight="8dp"
         app:progressBackgroundColor="@color/purple"
-        app:progressColor="@color/colorAccent"/>
+        app:progressColor="@color/colorAccent" />
 </merge>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -34,7 +34,7 @@
     <com.teresaholfeld.stories.StoriesProgressView
         android:id="@+id/stories"
         android:layout_width="match_parent"
-        android:layout_height="3dp"
+        android:layout_height="40dp"
         android:layout_gravity="top"
         android:layout_marginTop="8dp"
         android:paddingLeft="8dp"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -34,7 +34,7 @@
     <com.teresaholfeld.stories.StoriesProgressView
         android:id="@+id/stories"
         android:layout_width="match_parent"
-        android:layout_height="16dp"
+        android:layout_height="8dp"
         android:layout_gravity="top"
         android:layout_marginTop="8dp"
         android:paddingLeft="8dp"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -34,12 +34,12 @@
     <com.teresaholfeld.stories.StoriesProgressView
         android:id="@+id/stories"
         android:layout_width="match_parent"
-        android:layout_height="40dp"
+        android:layout_height="4dp"
         android:layout_gravity="top"
         android:layout_marginTop="8dp"
         android:paddingLeft="8dp"
         android:paddingRight="8dp"
         app:progressBackgroundColor="@color/purple"
         app:progressColor="@color/colorAccent"
-        app:progressGap="8dp" />
+        app:progressGap="4dp" />
 </merge>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -41,6 +41,5 @@
         android:paddingRight="8dp"
         app:progressBackgroundColor="@color/purple"
         app:progressColor="@color/colorAccent"
-        app:progressGap="8dp"
-        app:progressHeight="40dp" />
+        app:progressGap="8dp" />
 </merge>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -34,12 +34,13 @@
     <com.teresaholfeld.stories.StoriesProgressView
         android:id="@+id/stories"
         android:layout_width="match_parent"
-        android:layout_height="4dp"
+        android:layout_height="16dp"
         android:layout_gravity="top"
         android:layout_marginTop="8dp"
         android:paddingLeft="8dp"
         android:paddingRight="8dp"
         app:progressBackgroundColor="@color/purple"
+        app:cornerRadius="4dp"
         app:progressColor="@color/colorAccent"
         app:progressGap="4dp" />
 </merge>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -40,5 +40,7 @@
         android:paddingLeft="8dp"
         android:paddingRight="8dp"
         app:progressBackgroundColor="@color/purple"
-        app:progressColor="@color/colorAccent" />
+        app:progressColor="@color/colorAccent"
+        app:progressGap="8dp"
+        app:progressHeight="40dp" />
 </merge>

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext.kotlin_version = '1.5.10'
     repositories {
         google()
         jcenter()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.2.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -1,29 +1,29 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-  ext.kotlin_version = '1.3.21'
-  repositories {
-    google()
-    jcenter()
-    mavenCentral()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.3.1'
-    classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    // NOTE: Do not place your application dependencies here; they belong
-    // in the individual module build.gradle files
-  }
+    ext.kotlin_version = '1.4.10'
+    repositories {
+        google()
+        jcenter()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
 }
 
 allprojects {
-  repositories {
-    google()
-    jcenter()
-    maven { url "https://jitpack.io" }
-  }
+    repositories {
+        google()
+        jcenter()
+        maven { url "https://jitpack.io" }
+    }
 }
 
 task clean(type: Delete) {
-  delete rootProject.buildDir
+    delete rootProject.buildDir
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,8 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 
 # When configured, Gradle will run in incubating parallel mode.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 10 10:57:05 WEST 2018
+#Thu Sep 24 18:15:02 BST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -25,9 +25,9 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.2.1'
-    testImplementation 'junit:junit:4.13'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'com.google.android.material:material:1.3.0'
+    testImplementation 'junit:junit:4.13.2'
     androidTestImplementation('androidx.test.espresso:espresso-core:3.3.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -26,6 +26,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'com.google.android.material:material:1.2.1'
     testImplementation 'junit:junit:4.13'
     androidTestImplementation('androidx.test.espresso:espresso-core:3.3.0', {
         exclude group: 'com.android.support', module: 'support-annotations'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,35 +3,34 @@ apply plugin: 'kotlin-android'
 apply plugin: 'com.github.dcendents.android-maven'
 
 android {
-  compileSdkVersion 28
-  buildToolsVersion '28.0.3'
-  group = "com.teresaholfeld.stories"
+    compileSdkVersion 30
+    group = "com.teresaholfeld.stories"
 
-  defaultConfig {
-    minSdkVersion 15
-    targetSdkVersion 28
-    versionCode 1
-    versionName "1.1.4"
+    defaultConfig {
+        minSdkVersion 15
+        targetSdkVersion 30
+        versionCode 2
+        versionName "1.1.5"
 
-    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
-  }
-  buildTypes {
-    release {
-      minifyEnabled false
-      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
-  }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
 }
 
 dependencies {
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-  implementation 'com.android.support:appcompat-v7:28.0.0'
-  testImplementation 'junit:junit:4.12'
-  androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
-    exclude group: 'com.android.support', module: 'support-annotations'
-  })
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    testImplementation 'junit:junit:4.13'
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.3.0', {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    })
 }
 repositories {
-  mavenCentral()
+    mavenCentral()
 }

--- a/library/src/main/java/com/teresaholfeld/stories/PausableProgressBar.kt
+++ b/library/src/main/java/com/teresaholfeld/stories/PausableProgressBar.kt
@@ -10,13 +10,25 @@ import android.view.animation.LinearInterpolator
 import android.view.animation.ScaleAnimation
 import android.view.animation.Transformation
 import android.widget.FrameLayout
+import androidx.core.view.ViewCompat
+import com.google.android.material.shape.CornerFamily
+import com.google.android.material.shape.MaterialShapeDrawable
+import com.google.android.material.shape.ShapeAppearanceModel
 
 @SuppressLint("ViewConstructor")
-internal class PausableProgressBar constructor(context: Context,
-                                               attrs: AttributeSet? = null,
-                                               progressColor: Int,
-                                               progressBackgroundColor: Int)
-    : FrameLayout(context, attrs) {
+internal class PausableProgressBar(
+    context: Context,
+    attrs: AttributeSet? = null,
+    progressColor: Int,
+    progressBackgroundColor: Int,
+    cornerRadius: Int
+) : FrameLayout(context, attrs) {
+    constructor(
+        context: Context,
+        progressColor: Int,
+        progressBackgroundColor: Int,
+        cornerRadius: Int
+    ) : this(context, null, progressColor, progressBackgroundColor, cornerRadius)
 
     private val frontProgressView: View?
     private val backProgressView: View?
@@ -30,17 +42,16 @@ internal class PausableProgressBar constructor(context: Context,
         fun onFinishProgress()
     }
 
-    constructor(context: Context,
-                progressColor: Int,
-                progressBackgroundColor: Int)
-        : this(context, null, progressColor, progressBackgroundColor)
-
     init {
         LayoutInflater.from(context).inflate(R.layout.pausable_progress, this)
         frontProgressView = findViewById(R.id.front_progress)
         backProgressView = findViewById(R.id.back_progress)
         backProgressView?.setBackgroundColor(progressBackgroundColor)
         frontProgressView?.setBackgroundColor(progressColor)
+        val allCorners = ShapeAppearanceModel().toBuilder().setAllCorners(CornerFamily.ROUNDED, cornerRadius.toFloat()).build()
+        val materialShapeDrawable = MaterialShapeDrawable(allCorners)
+        ViewCompat.setBackground(frontProgressView, materialShapeDrawable)
+        ViewCompat.setBackground(backProgressView, materialShapeDrawable)
     }
 
     fun setDuration(duration: Long) {
@@ -116,13 +127,13 @@ internal class PausableProgressBar constructor(context: Context,
     }
 
     private class PausableScaleAnimation(fromX: Float,
-                                               toX: Float,
-                                               fromY: Float,
-                                               toY: Float,
-                                               pivotXType: Int,
-                                               pivotXValue: Float,
-                                               pivotYType: Int,
-                                               pivotYValue: Float)
+                                         toX: Float,
+                                         fromY: Float,
+                                         toY: Float,
+                                         pivotXType: Int,
+                                         pivotXValue: Float,
+                                         pivotYType: Int,
+                                         pivotYValue: Float)
         : ScaleAnimation(fromX, toX, fromY, toY, pivotXType, pivotXValue, pivotYType, pivotYValue) {
 
         private var mElapsedAtPause: Long = 0

--- a/library/src/main/java/com/teresaholfeld/stories/PausableProgressBar.kt
+++ b/library/src/main/java/com/teresaholfeld/stories/PausableProgressBar.kt
@@ -11,7 +11,6 @@ import android.view.animation.LinearInterpolator
 import android.view.animation.ScaleAnimation
 import android.view.animation.Transformation
 import android.widget.FrameLayout
-import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable

--- a/library/src/main/java/com/teresaholfeld/stories/PausableProgressBar.kt
+++ b/library/src/main/java/com/teresaholfeld/stories/PausableProgressBar.kt
@@ -115,14 +115,14 @@ internal class PausableProgressBar constructor(context: Context,
         animation = null
     }
 
-    private inner class PausableScaleAnimation internal constructor(fromX: Float,
-                                                                    toX: Float,
-                                                                    fromY: Float,
-                                                                    toY: Float,
-                                                                    pivotXType: Int,
-                                                                    pivotXValue: Float,
-                                                                    pivotYType: Int,
-                                                                    pivotYValue: Float)
+    private inner class PausableScaleAnimation(fromX: Float,
+                                               toX: Float,
+                                               fromY: Float,
+                                               toY: Float,
+                                               pivotXType: Int,
+                                               pivotXValue: Float,
+                                               pivotYType: Int,
+                                               pivotYValue: Float)
         : ScaleAnimation(fromX, toX, fromY, toY, pivotXType, pivotXValue, pivotYType, pivotYValue) {
 
         private var mElapsedAtPause: Long = 0
@@ -141,7 +141,7 @@ internal class PausableProgressBar constructor(context: Context,
         /***
          * pause animation
          */
-        internal fun pause() {
+        fun pause() {
             if (mPaused) return
             mElapsedAtPause = 0
             mPaused = true
@@ -150,7 +150,7 @@ internal class PausableProgressBar constructor(context: Context,
         /***
          * resume animation
          */
-        internal fun resume() {
+        fun resume() {
             mPaused = false
         }
     }

--- a/library/src/main/java/com/teresaholfeld/stories/PausableProgressBar.kt
+++ b/library/src/main/java/com/teresaholfeld/stories/PausableProgressBar.kt
@@ -2,6 +2,7 @@ package com.teresaholfeld.stories
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.res.ColorStateList
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
@@ -10,6 +11,7 @@ import android.view.animation.LinearInterpolator
 import android.view.animation.ScaleAnimation
 import android.view.animation.Transformation
 import android.widget.FrameLayout
+import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable
@@ -46,12 +48,17 @@ internal class PausableProgressBar(
         LayoutInflater.from(context).inflate(R.layout.pausable_progress, this)
         frontProgressView = findViewById(R.id.front_progress)
         backProgressView = findViewById(R.id.back_progress)
-        backProgressView?.setBackgroundColor(progressBackgroundColor)
-        frontProgressView?.setBackgroundColor(progressColor)
-        val allCorners = ShapeAppearanceModel().toBuilder().setAllCorners(CornerFamily.ROUNDED, cornerRadius.toFloat()).build()
+        ViewCompat.setBackground(frontProgressView, createBackgroundDrawable(progressColor, cornerRadius))
+        ViewCompat.setBackground(backProgressView, createBackgroundDrawable(progressBackgroundColor, cornerRadius))
+    }
+
+    private fun createBackgroundDrawable(color: Int, cornerRadius: Int): MaterialShapeDrawable {
+        val allCorners = ShapeAppearanceModel().toBuilder()
+            .setAllCorners(CornerFamily.ROUNDED, cornerRadius.toFloat())
+            .build()
         val materialShapeDrawable = MaterialShapeDrawable(allCorners)
-        ViewCompat.setBackground(frontProgressView, materialShapeDrawable)
-        ViewCompat.setBackground(backProgressView, materialShapeDrawable)
+        materialShapeDrawable.fillColor = ColorStateList.valueOf(color)
+        return materialShapeDrawable
     }
 
     fun setDuration(duration: Long) {

--- a/library/src/main/java/com/teresaholfeld/stories/PausableProgressBar.kt
+++ b/library/src/main/java/com/teresaholfeld/stories/PausableProgressBar.kt
@@ -115,7 +115,7 @@ internal class PausableProgressBar constructor(context: Context,
         animation = null
     }
 
-    private inner class PausableScaleAnimation(fromX: Float,
+    private class PausableScaleAnimation(fromX: Float,
                                                toX: Float,
                                                fromY: Float,
                                                toY: Float,

--- a/library/src/main/java/com/teresaholfeld/stories/StoriesProgressView.kt
+++ b/library/src/main/java/com/teresaholfeld/stories/StoriesProgressView.kt
@@ -14,11 +14,14 @@ class StoriesProgressView : LinearLayout {
 
     private val progressBarLayoutParams = LayoutParams(0, LayoutParams.MATCH_PARENT, 1f)
 
-    private var progressGapInPixels: Int? = null
     private val defaultGap = 5
+    private var progressGapInPixels = defaultGap
     private val gapLayoutParams by lazy {
-        LayoutParams(progressGapInPixels ?: defaultGap, LayoutParams.MATCH_PARENT)
+
     }
+
+    private val defaultCornerRadius = 0
+    private var progressCornerRadius = defaultCornerRadius
 
     private val defaultColor = ContextCompat.getColor(context, R.color.progress_primary)
     private val defaultBackgroundColor = ContextCompat.getColor(context, R.color.progress_secondary)
@@ -70,6 +73,7 @@ class StoriesProgressView : LinearLayout {
         progressColor = typedArray.getColor(R.styleable.StoriesProgressView_progressColor, defaultColor)
         progressBackgroundColor = typedArray.getColor(R.styleable.StoriesProgressView_progressBackgroundColor, defaultBackgroundColor)
         progressGapInPixels = typedArray.getDimensionPixelSize(R.styleable.StoriesProgressView_progressGap, 0)
+        progressCornerRadius = typedArray.getDimensionPixelSize(R.styleable.StoriesProgressView_cornerRadius, 0)
         typedArray.recycle()
         bindViews()
     }
@@ -89,14 +93,14 @@ class StoriesProgressView : LinearLayout {
     }
 
     private fun createProgressBar(): PausableProgressBar {
-        val p = PausableProgressBar(context, progressColor, progressBackgroundColor)
+        val p = PausableProgressBar(context, progressColor, progressBackgroundColor, progressCornerRadius)
         p.layoutParams = progressBarLayoutParams
         return p
     }
 
     private fun createSpace(): View {
         val v = View(context)
-        v.layoutParams = gapLayoutParams
+        v.layoutParams = LayoutParams(progressGapInPixels, LayoutParams.MATCH_PARENT)
         return v
     }
 

--- a/library/src/main/java/com/teresaholfeld/stories/StoriesProgressView.kt
+++ b/library/src/main/java/com/teresaholfeld/stories/StoriesProgressView.kt
@@ -9,7 +9,6 @@ import android.util.AttributeSet
 import android.view.View
 import android.widget.LinearLayout
 import androidx.core.content.ContextCompat
-import java.util.ArrayList
 
 class StoriesProgressView : LinearLayout {
 
@@ -27,7 +26,7 @@ class StoriesProgressView : LinearLayout {
     private var progressColor = defaultColor
     private var progressBackgroundColor = defaultBackgroundColor
 
-    private val progressBars = ArrayList<PausableProgressBar>()
+    private val progressBars = mutableListOf<PausableProgressBar>()
 
     private var storiesCount = -1
 

--- a/library/src/main/java/com/teresaholfeld/stories/StoriesProgressView.kt
+++ b/library/src/main/java/com/teresaholfeld/stories/StoriesProgressView.kt
@@ -5,16 +5,16 @@ package com.teresaholfeld.stories
 import android.annotation.TargetApi
 import android.content.Context
 import android.os.Build
-import android.support.v4.content.ContextCompat
 import android.util.AttributeSet
 import android.view.View
 import android.widget.LinearLayout
+import androidx.core.content.ContextCompat
 import java.util.ArrayList
 
 class StoriesProgressView : LinearLayout {
 
-    private val progressBarLayoutParam = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
-    private val spaceLayoutParam = LinearLayout.LayoutParams(5, LinearLayout.LayoutParams.WRAP_CONTENT)
+    private val progressBarLayoutParam = LayoutParams(0, LayoutParams.WRAP_CONTENT, 1f)
+    private val spaceLayoutParam = LayoutParams(5, LayoutParams.WRAP_CONTENT)
     private val defaultColor = ContextCompat.getColor(context, R.color.progress_primary)
     private val defaultBackgroundColor = ContextCompat.getColor(context, R.color.progress_secondary)
 
@@ -24,6 +24,7 @@ class StoriesProgressView : LinearLayout {
     private val progressBars = ArrayList<PausableProgressBar>()
 
     private var storiesCount = -1
+
     /**
      * pointer of running animation
      */
@@ -42,7 +43,8 @@ class StoriesProgressView : LinearLayout {
         fun onComplete()
     }
 
-    @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) : super(context, attrs) {
+    @JvmOverloads
+    constructor(context: Context, attrs: AttributeSet? = null) : super(context, attrs) {
         init(context, attrs)
     }
 
@@ -57,7 +59,7 @@ class StoriesProgressView : LinearLayout {
     }
 
     private fun init(context: Context, attrs: AttributeSet?) {
-        orientation = LinearLayout.HORIZONTAL
+        orientation = HORIZONTAL
         val typedArray = context.obtainStyledAttributes(attrs, R.styleable.StoriesProgressView)
         storiesCount = typedArray.getInt(R.styleable.StoriesProgressView_progressCount, 0)
         progressColor = typedArray.getColor(R.styleable.StoriesProgressView_progressColor, defaultColor)

--- a/library/src/main/java/com/teresaholfeld/stories/StoriesProgressView.kt
+++ b/library/src/main/java/com/teresaholfeld/stories/StoriesProgressView.kt
@@ -69,8 +69,8 @@ class StoriesProgressView : LinearLayout {
         storiesCount = typedArray.getInt(R.styleable.StoriesProgressView_progressCount, 0)
         progressColor = typedArray.getColor(R.styleable.StoriesProgressView_progressColor, defaultColor)
         progressBackgroundColor = typedArray.getColor(R.styleable.StoriesProgressView_progressBackgroundColor, defaultBackgroundColor)
-        progressGapInPixels = typedArray.getDimensionPixelSize(R.styleable.StoriesProgressView_progressGap, 0)
-        progressCornerRadius = typedArray.getDimensionPixelSize(R.styleable.StoriesProgressView_cornerRadius, 0)
+        progressGapInPixels = typedArray.getDimensionPixelSize(R.styleable.StoriesProgressView_progressGap, defaultGap)
+        progressCornerRadius = typedArray.getDimensionPixelSize(R.styleable.StoriesProgressView_cornerRadius, defaultCornerRadius)
         typedArray.recycle()
         bindViews()
     }

--- a/library/src/main/java/com/teresaholfeld/stories/StoriesProgressView.kt
+++ b/library/src/main/java/com/teresaholfeld/stories/StoriesProgressView.kt
@@ -16,9 +16,6 @@ class StoriesProgressView : LinearLayout {
 
     private val defaultGap = 5
     private var progressGapInPixels = defaultGap
-    private val gapLayoutParams by lazy {
-
-    }
 
     private val defaultCornerRadius = 0
     private var progressCornerRadius = defaultCornerRadius

--- a/library/src/main/java/com/teresaholfeld/stories/StoriesProgressView.kt
+++ b/library/src/main/java/com/teresaholfeld/stories/StoriesProgressView.kt
@@ -13,17 +13,12 @@ import java.util.ArrayList
 
 class StoriesProgressView : LinearLayout {
 
-    private var progressHeightInPixels: Int? = null
-    private val defaultHeight = LayoutParams.WRAP_CONTENT
-    private val actualHeight by lazy { progressHeightInPixels ?: defaultHeight }
-    private val progressBarLayoutParams by lazy {
-        LayoutParams(0, actualHeight, 1f)
-    }
+    private val progressBarLayoutParams = LayoutParams(0, LayoutParams.MATCH_PARENT, 1f)
 
     private var progressGapInPixels: Int? = null
     private val defaultGap = 5
     private val gapLayoutParams by lazy {
-        LayoutParams(progressGapInPixels ?: defaultGap, actualHeight)
+        LayoutParams(progressGapInPixels ?: defaultGap, LayoutParams.MATCH_PARENT)
     }
 
     private val defaultColor = ContextCompat.getColor(context, R.color.progress_primary)
@@ -75,7 +70,6 @@ class StoriesProgressView : LinearLayout {
         storiesCount = typedArray.getInt(R.styleable.StoriesProgressView_progressCount, 0)
         progressColor = typedArray.getColor(R.styleable.StoriesProgressView_progressColor, defaultColor)
         progressBackgroundColor = typedArray.getColor(R.styleable.StoriesProgressView_progressBackgroundColor, defaultBackgroundColor)
-        progressHeightInPixels = typedArray.getDimensionPixelSize(R.styleable.StoriesProgressView_progressHeight, 0)
         progressGapInPixels = typedArray.getDimensionPixelSize(R.styleable.StoriesProgressView_progressGap, 0)
         typedArray.recycle()
         bindViews()

--- a/library/src/main/java/com/teresaholfeld/stories/StoriesProgressView.kt
+++ b/library/src/main/java/com/teresaholfeld/stories/StoriesProgressView.kt
@@ -13,8 +13,19 @@ import java.util.ArrayList
 
 class StoriesProgressView : LinearLayout {
 
-    private val progressBarLayoutParam = LayoutParams(0, LayoutParams.WRAP_CONTENT, 1f)
-    private val spaceLayoutParam = LayoutParams(5, LayoutParams.WRAP_CONTENT)
+    private var progressHeightInPixels: Int? = null
+    private val defaultHeight = LayoutParams.WRAP_CONTENT
+    private val actualHeight by lazy { progressHeightInPixels ?: defaultHeight }
+    private val progressBarLayoutParams by lazy {
+        LayoutParams(0, actualHeight, 1f)
+    }
+
+    private var progressGapInPixels: Int? = null
+    private val defaultGap = 5
+    private val gapLayoutParams by lazy {
+        LayoutParams(progressGapInPixels ?: defaultGap, actualHeight)
+    }
+
     private val defaultColor = ContextCompat.getColor(context, R.color.progress_primary)
     private val defaultBackgroundColor = ContextCompat.getColor(context, R.color.progress_secondary)
 
@@ -63,8 +74,9 @@ class StoriesProgressView : LinearLayout {
         val typedArray = context.obtainStyledAttributes(attrs, R.styleable.StoriesProgressView)
         storiesCount = typedArray.getInt(R.styleable.StoriesProgressView_progressCount, 0)
         progressColor = typedArray.getColor(R.styleable.StoriesProgressView_progressColor, defaultColor)
-        progressBackgroundColor = typedArray.getColor(R.styleable.StoriesProgressView_progressBackgroundColor,
-            defaultBackgroundColor)
+        progressBackgroundColor = typedArray.getColor(R.styleable.StoriesProgressView_progressBackgroundColor, defaultBackgroundColor)
+        progressHeightInPixels = typedArray.getDimensionPixelSize(R.styleable.StoriesProgressView_progressHeight, 0)
+        progressGapInPixels = typedArray.getDimensionPixelSize(R.styleable.StoriesProgressView_progressGap, 0)
         typedArray.recycle()
         bindViews()
     }
@@ -85,13 +97,13 @@ class StoriesProgressView : LinearLayout {
 
     private fun createProgressBar(): PausableProgressBar {
         val p = PausableProgressBar(context, progressColor, progressBackgroundColor)
-        p.layoutParams = progressBarLayoutParam
+        p.layoutParams = progressBarLayoutParams
         return p
     }
 
     private fun createSpace(): View {
         val v = View(context)
-        v.layoutParams = spaceLayoutParam
+        v.layoutParams = gapLayoutParams
         return v
     }
 

--- a/library/src/main/res/layout/pausable_progress.xml
+++ b/library/src/main/res/layout/pausable_progress.xml
@@ -1,27 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    xmlns:tools="http://schemas.android.com/tools">
+    android:layout_height="match_parent"
+    tools:layout_height="8dp">
 
     <View
         android:id="@+id/back_progress"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/progress_bar_height"
+        android:layout_height="match_parent"
         android:background="@color/progress_secondary" />
 
     <View
         android:id="@+id/front_progress"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/progress_bar_height"
+        android:layout_height="match_parent"
         android:background="@color/progress_primary"
         android:visibility="invisible"
-        tools:visibility="visible"/>
+        tools:visibility="visible" />
 
     <View
         android:id="@+id/max_progress"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/progress_bar_height"
+        android:layout_height="match_parent"
         android:background="#fff"
         android:visibility="gone" />
 </FrameLayout>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -5,5 +5,6 @@
         <attr name="progressColor" format="color" />
         <attr name="progressBackgroundColor" format="color" />
         <attr name="progressGap" format="dimension" />
+        <attr name="cornerRadius" format="dimension" />
     </declare-styleable>
 </resources>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -4,7 +4,6 @@
         <attr name="progressCount" format="integer|reference" />
         <attr name="progressColor" format="color" />
         <attr name="progressBackgroundColor" format="color" />
-        <attr name="progressHeight" format="dimension" />
         <attr name="progressGap" format="dimension" />
     </declare-styleable>
 </resources>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="StoriesProgressView">
-        <attr name="progressCount" format="integer|reference"/>
-        <attr name="progressColor" format="color"/>
-        <attr name="progressBackgroundColor" format="color"/>
+        <attr name="progressCount" format="integer|reference" />
+        <attr name="progressColor" format="color" />
+        <attr name="progressBackgroundColor" format="color" />
+        <attr name="progressHeight" format="dimension" />
+        <attr name="progressGap" format="dimension" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
This PR will update:
- Android Gradle Plugin -> 4.0.1
- Gradle -> 6.6
- Kotlin -> 1.4.10
- Android Support Library -> AndroidX
- Sample app -> now uses library in project instead of 1.1.2

This PR fixes:
- Sample app: No findViewById call to set up stories progress view, was causing the stories progress view to not appear
- StoriesProgressView: Now respects `layout_height`, all child views are set to `match_parent`, allows library users to change height of progress bar

This PR adds:
- StoriesProgressView: `progressGap` argument added, allowing library users to change the width of the gap between progress bars, fixes #8 
- StoriesProgressView: `cornerRadius` argument added, allowing library users to round the corners of the progress bars, fixes #10 

In order to add the rounded corners, the progress bar views now have a `MaterialShapeDrawable` placed on them. This requires the Material Components dependency, which has been added to the `library` module.
